### PR TITLE
refactor: improve documentation conciseness across core services

### DIFF
--- a/src/api/routers/financial_analysis.py
+++ b/src/api/routers/financial_analysis.py
@@ -1,72 +1,19 @@
-"""FastAPI router for financial analysis and contract discrepancy detection endpoints.
+"""FastAPI router for financial analysis and contract discrepancy detection.
 
-This module provides RESTful API endpoints for the Financial Analyst RAG system,
-offering comprehensive financial analysis capabilities for restaurant partnership
-contracts and payout reports. It serves as the primary interface for accessing
-sophisticated AI-powered financial discrepancy detection and analysis services.
-
-The router implements enterprise-grade endpoints that leverage the FinancialAnalystRAGChain
-to provide detailed analysis of contract-to-payout discrepancies, partner document
-management, and comprehensive financial reporting capabilities. All endpoints are
-designed with production considerations including proper error handling, request
-validation, and comprehensive response formatting.
+Provides RESTful API endpoints for analyzing restaurant partnership contracts
+and payout reports using the FinancialAnalystRAGChain.
 
 Key Endpoints:
-    - /analyze-discrepancies: Core financial discrepancy analysis
-    - /partner-summary: Document availability and metadata overview
-    - /query-documents: General document querying and analysis
-    - /detailed-report: Comprehensive financial analysis reports
+    - /analyze-discrepancies: Financial discrepancy analysis
+    - /partner-summary: Document overview and metadata
+    - /query-documents: General document querying
+    - /detailed-report: Comprehensive analysis reports
 
-Financial Analysis Capabilities:
-    - Contract-to-payout discrepancy identification
-    - Commission rate variance calculations
-    - Service fee analysis and validation
-    - Penalty application verification
-    - Multi-document comparative analysis
-    - Executive summary generation
-
-Request/Response Models:
-    - AnalysisRequest: Standardized analysis request format
-    - AnalysisResponse: Comprehensive analysis results
-    - Proper validation and error handling for all interactions
-
-Security and Validation:
-    - Input validation using Pydantic models
-    - Comprehensive error handling with appropriate HTTP status codes
-    - Detailed logging for audit trails and debugging
-    - Resource management and timeout considerations
-
-Example Usage:
+Example:
     ```python
-    # Analyze contract discrepancies
-    POST /financial-analysis/analyze-discrepancies
-    {
-        "partner_name": "SushiExpress24-7",
-        "question": "Compare commission rates between contract and payout report"
-    }
-    
-    # Get partner document summary
-    GET /financial-analysis/partner-summary/SushiExpress24-7
+    # POST /analyze-discrepancies
+    request = {"partner_name": "Restaurant", "analysis_type": "full"}
     ```
-
-Integration:
-    - RAG service integration for AI-powered analysis
-    - OpenSearch connectivity for document retrieval
-    - Comprehensive logging and monitoring
-    - Error handling with detailed diagnostics
-
-Dependencies:
-    - fastapi: Modern web framework for API development
-    - pydantic: Data validation and serialization
-    - rag_service: Core financial analysis logic
-    - logging: Comprehensive operation monitoring
-
-Note:
-    This router implements the core Task 2 functionality for financial
-    contract analysis using LangChain RAG pipeline with GPT-4 integration.
-
-Version:
-    2.0.0 - Enhanced with comprehensive analysis endpoints and validation
 """
 import logging
 from typing import Dict, Any, Optional
@@ -87,25 +34,9 @@ rag_chain = FinancialAnalystRAGChain()
 class AnalysisRequest(BaseModel):
     """Request model for financial analysis operations.
     
-    This model defines the standard request format for financial discrepancy
-    analysis operations, providing comprehensive validation and documentation
-    for client interactions with the analysis endpoints.
-    
     Attributes:
-        partner_name (str): Name of the restaurant partner for analysis.
-            Must match exactly with indexed partner names for accurate
-            document retrieval and analysis.
-        question (Optional[str]): Specific analysis question to guide the
-            financial analysis. If None, a comprehensive default analysis
-            will be performed covering all major discrepancy types.
-    
-    Example:
-        ```json
-        {
-            "partner_name": "SushiExpress24-7",
-            "question": "Compare commission rates between contract and payout report"
-        }
-        ```
+        partner_name (str): Restaurant partner name for analysis.
+        question (Optional[str]): Specific analysis question or None for default.
     """
     partner_name: str
     question: Optional[str] = None
@@ -114,32 +45,12 @@ class AnalysisRequest(BaseModel):
 class AnalysisResponse(BaseModel):
     """Response model for financial analysis operations.
     
-    This model defines the comprehensive response format for financial
-    analysis operations, providing structured results with detailed
-    analysis content and metadata for client applications.
-    
     Attributes:
-        partner_name (str): Name of the restaurant partner analyzed.
-        question (str): The analysis question that was processed.
-        analysis (str): Detailed financial analysis results with
-            discrepancy identification and explanations.
-        document_summary (Dict[str, Any]): Summary of documents used
-            in the analysis including counts and metadata.
-        status (str): Operation status indicator (success/error).
-    
-    Example:
-        ```json
-        {
-            "partner_name": "SushiExpress24-7",
-            "question": "Compare commission rates...",
-            "analysis": "Based on the contract analysis...",
-            "document_summary": {
-                "total_documents": 15,
-                "document_types": {...}
-            },
-            "status": "success"
-        }
-        ```
+        partner_name (str): Restaurant partner analyzed.
+        question (str): Analysis question processed.
+        analysis (str): Financial analysis results.
+        document_summary (Dict[str, Any]): Documents used in analysis.
+        status (str): Operation status (success/error).
     """
     partner_name: str
     question: str
@@ -150,101 +61,16 @@ class AnalysisResponse(BaseModel):
 
 @router.post("/analyze-discrepancies", response_model=AnalysisResponse)
 async def analyze_discrepancies(request: AnalysisRequest):
-    """Perform comprehensive financial discrepancy analysis between contracts and payout reports.
-    
-    This endpoint implements the core financial analysis functionality, providing
-    sophisticated AI-powered analysis of discrepancies between restaurant partnership
-    contracts and their corresponding payout reports. It leverages the LangChain RAG
-    pipeline with GPT-4 to deliver expert-level financial insights and calculations.
-    
-    Analysis Capabilities:
-        - Contract-to-payout discrepancy identification
-        - Commission rate variance analysis and calculations
-        - Service fee comparison and validation
-        - Penalty application verification with contractual basis
-        - Multi-document cross-referencing for accuracy
-        - Detailed financial explanations with supporting evidence
-    
-    Processing Pipeline:
-        1. Partner document validation and availability check
-        2. Document summary generation for context
-        3. Question processing and default analysis setup
-        4. RAG-powered financial analysis execution
-        5. Comprehensive response formatting and validation
-    
-    Default Analysis:
-        When no specific question is provided, the endpoint performs a
-        comprehensive analysis covering:
-        - Service fees and their contractual basis
-        - Penalties and calculation methodologies
-        - Payout amount variances and explanations
-        - Overall financial reconciliation
+    """Analyze financial discrepancies between contracts and payout reports.
     
     Args:
-        request (AnalysisRequest): Analysis request containing partner name
-            and optional specific question. The partner_name must match
-            exactly with indexed partner names for accurate document
-            retrieval and analysis.
-    
+        request: Analysis request with partner name and optional question.
+        
     Returns:
-        AnalysisResponse: Comprehensive analysis results including:
-            - Detailed financial analysis with calculations
-            - Document summary with metadata
-            - Processing status and validation results
-            - Original question for reference
-    
+        Analysis response with results and document summary.
+        
     Raises:
-        HTTPException 404: When no documents are found for the specified
-            partner. Indicates that document indexing may be incomplete
-            or partner name is incorrect.
-        HTTPException 500: When analysis processing fails due to service
-            issues, document problems, or AI service limitations.
-    
-    Example:
-        ```python
-        # Request comprehensive analysis
-        POST /financial-analysis/analyze-discrepancies
-        Content-Type: application/json
-        
-        {
-            "partner_name": "SushiExpress24-7",
-            "question": "Identify commission rate discrepancies and calculate variance amounts"
-        }
-        
-        # Response
-        {
-            "partner_name": "SushiExpress24-7",
-            "question": "Identify commission rate discrepancies...",
-            "analysis": "Based on comprehensive analysis of SushiExpress24-7 documents...",
-            "document_summary": {
-                "total_documents": 15,
-                "document_types": {
-                    "contract": {"count": 8, "files": ["partnership_agreement.pdf"]},
-                    "payout_report": {"count": 7, "files": ["payout_2024_07_21.txt"]}
-                }
-            },
-            "status": "success"
-        }
-        ```
-    
-    Business Use Cases:
-        - Monthly financial reconciliation processes
-        - Contract compliance verification
-        - Discrepancy investigation and resolution
-        - Executive reporting and analysis
-        - Automated financial auditing
-    
-    Performance:
-        - Optimized document retrieval for large partner datasets
-        - Intelligent context creation for focused analysis
-        - Efficient AI processing with minimal latency
-        - Comprehensive error handling and recovery
-    
-    Note:
-        This endpoint represents the primary business logic for financial
-        contract analysis in the restaurant partnership domain, providing
-        production-ready analysis capabilities with enterprise-grade
-        reliability and accuracy.
+        HTTPException: If analysis fails or partner not found.
     """
     try:
         # Get partner document summary
@@ -283,103 +109,16 @@ async def analyze_discrepancies(request: AnalysisRequest):
 
 @router.get("/partner-summary/{partner_name}")
 async def get_partner_summary(partner_name: str):
-    """Retrieve comprehensive document summary and metadata for a specific restaurant partner.
-    
-    This endpoint provides detailed information about all available documents
-    for a restaurant partner, including document counts, types, file information,
-    and processing metadata. It serves as a health check and inventory endpoint
-    for partner document availability before performing analysis operations.
-    
-    Summary Information:
-        - Total document count across all types
-        - Document type breakdown with individual counts
-        - File names and metadata for each document type
-        - Content statistics including total character counts
-        - Processing timestamps and validation status
-    
-    Document Types:
-        - contract: Partnership agreements and legal documents
-        - payout_report: Financial transaction records and summaries
-        - other: Additional relevant documents and addendums
-    
-    Use Cases:
-        - Pre-analysis validation of document availability
-        - Document inventory management and tracking
-        - Processing status verification for uploaded documents
-        - Client application data availability checks
-        - Administrative partner management operations
+    """Get document summary for a restaurant partner.
     
     Args:
-        partner_name (str): Name of the restaurant partner for document
-            summary retrieval. Must match exactly with indexed partner
-            names for accurate document discovery.
-    
-    Returns:
-        Dict[str, Any]: Comprehensive partner summary containing:
-            - status: Operation success indicator
-            - partner_summary: Detailed document metadata including:
-                - partner_name: Confirmed partner identifier
-                - total_documents: Count of all available documents
-                - document_types: Breakdown by type with counts and files
-                - last_processed: Most recent processing timestamp
-    
-    Raises:
-        HTTPException 404: When no documents are found for the specified
-            partner. This indicates either:
-            - Partner name is incorrect or not indexed
-            - Document indexing is incomplete
-            - Documents have been removed or corrupted
-        HTTPException 500: When document retrieval fails due to:
-            - OpenSearch connectivity issues
-            - Service configuration problems
-            - System resource limitations
-    
-    Example:
-        ```python
-        # Request partner summary
-        GET /financial-analysis/partner-summary/SushiExpress24-7
+        partner_name (str): Restaurant partner name.
         
-        # Response
-        {
-            "status": "success",
-            "partner_summary": {
-                "partner_name": "SushiExpress24-7",
-                "total_documents": 15,
-                "document_types": {
-                    "contract": {
-                        "count": 8,
-                        "files": ["partnership_agreement.pdf"],
-                        "total_content_length": 25000
-                    },
-                    "payout_report": {
-                        "count": 7,
-                        "files": ["payout_2024_07_21.txt"],
-                        "total_content_length": 12000
-                    }
-                },
-                "last_processed": "2024-07-21T10:30:00Z"
-            }
-        }
-        ```
-    
-    Response Structure:
-        The partner summary provides comprehensive metadata enabling
-        clients to:
-        - Validate document availability before analysis requests
-        - Display document inventory in user interfaces
-        - Monitor processing status and document completeness
-        - Plan analysis operations based on available content
-    
-    Performance:
-        - Optimized document counting and metadata aggregation
-        - Cached results for frequently accessed partners
-        - Minimal resource usage for inventory operations
-        - Fast response times for client validation
-    
-    Note:
-        This endpoint is essential for client applications to validate
-        partner document availability and plan analysis operations
-        effectively before making resource-intensive analysis requests.
+    Returns:
+        Dict with document counts, types, and metadata.
+        
+    Raises:
+        HTTPException: If partner not found or service error.
     """
     try:
         summary = rag_chain.get_partner_summary(partner_name)

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -1,105 +1,21 @@
-"""Advanced document processing service for multi-format text extraction and intelligent chunking.
+"""Document processing service for multi-format text extraction and chunking.
 
-This module provides comprehensive document processing capabilities specifically
-designed for restaurant partnership contracts, payout reports, and financial
-documents. It handles multiple file formats with intelligent text extraction,
-semantic chunking, and metadata enrichment for optimal RAG system integration.
+Processes restaurant partnership contracts and payout reports with support for
+PDF, TXT, and MD formats. Provides intelligent text extraction, chunking, and
+metadata enrichment for RAG system integration.
 
-The service supports various document formats including PDF contracts, text-based
-payout reports, and structured financial documents. It implements sophisticated
-text extraction algorithms with fallback mechanisms, ensuring reliable content
-processing even for complex document layouts and formats.
-
-Key Capabilities:
+Key Features:
     - Multi-format document processing (PDF, TXT, MD)
-    - Intelligent text extraction with multiple PDF parsing backends
-    - Semantic-aware chunking with configurable overlap
-    - Comprehensive metadata enrichment and tracking
-    - File size validation and security checks
-    - Error handling with detailed diagnostics
-    - Production-grade logging and monitoring
-
-Document Processing Pipeline:
-    1. File validation and security checks
-    2. Format detection and appropriate parser selection
-    3. Text extraction with quality validation
-    4. Intelligent chunking with semantic preservation
-    5. Metadata enrichment and tracking
-    6. Quality assurance and error handling
-
-Supported Formats:
-    - PDF: Restaurant contracts, partnership agreements, legal documents
-    - TXT: Payout reports, financial summaries, structured data
-    - MD: Documentation, analysis reports, structured content
-
-PDF Processing Backends:
-    - pdfplumber: Primary backend for complex layouts and tables
-    - PyMuPDF (fitz): High-performance alternative for large documents
-    - PyPDF2: Fallback option for compatibility and simple documents
-
-Technical Features:
-    - Configurable chunk sizes for optimal RAG performance
-    - Overlapping chunks to preserve context boundaries
-    - Automatic metadata generation with document fingerprinting
-    - File size limits and security validation
-    - Memory-efficient processing for large documents
+    - Multiple PDF parsing backends (pdfplumber, PyMuPDF, PyPDF2)
+    - Configurable chunking with overlap preservation
+    - File validation and security checks
+    - Comprehensive metadata generation
 
 Example:
     ```python
-    # Initialize document processor
     processor = DocumentProcessor()
-    
-    # Process PDF contract
-    contract_chunks = processor.process_file(
-        file_path="partnership_agreement.pdf",
-        document_metadata={
-            "partner_name": "SushiExpress24-7",
-            "document_type": "contract"
-        }
-    )
-    
-    # Process text-based payout report
-    payout_chunks = processor.process_text(
-        text=payout_report_content,
-        document_metadata={
-            "partner_name": "SushiExpress24-7",
-            "document_type": "payout_report",
-            "report_date": "2024-07-21"
-        }
-    )
+    chunks = processor.process_file("contract.pdf", {"partner": "Restaurant"})
     ```
-
-Integration Points:
-    - Embedding service for vector generation
-    - OpenSearch indexing for document storage
-    - RAG service for context retrieval
-    - API endpoints for document upload and processing
-
-Performance Considerations:
-    - Streaming processing for large documents
-    - Memory optimization for batch operations
-    - Configurable processing parameters
-    - Intelligent caching for repeated operations
-
-Security Features:
-    - File size validation to prevent resource exhaustion
-    - File type validation for security compliance
-    - Path traversal protection
-    - Content validation and sanitization
-
-Dependencies:
-    - pdfplumber: Advanced PDF parsing with table support
-    - PyMuPDF (fitz): High-performance PDF processing
-    - PyPDF2: Compatibility and fallback PDF processing
-    - logging: Comprehensive operation monitoring
-
-Note:
-    This service requires at least one PDF processing library to be installed
-    for PDF document support. Multiple backends provide redundancy and
-    optimization options for different document types.
-
-Version:
-    2.0.0 - Enhanced with multi-backend PDF processing and production optimizations
 """
 import logging
 from typing import List, Dict, Any, Optional
@@ -129,106 +45,21 @@ logger = logging.getLogger(__name__)
 
 
 class DocumentProcessor:
-    """Production-grade document processing service for multi-format text extraction and chunking.
+    """Processes restaurant contracts and payout reports with multi-format support.
     
-    This service provides enterprise-level document processing capabilities specifically
-    optimized for restaurant partnership contracts, financial payout reports, and
-    related business documents. It implements sophisticated text extraction algorithms
-    with multiple backend support, intelligent chunking strategies, and comprehensive
-    metadata management.
-    
-    The processor handles complex document layouts, tables, and various formatting
-    challenges commonly found in legal contracts and financial reports. It provides
-    robust fallback mechanisms and detailed error handling to ensure reliable
-    processing across diverse document types and quality levels.
-    
-    Processing Capabilities:
-        - Multi-format document support (PDF, TXT, MD)
-        - Advanced PDF parsing with table and layout preservation
-        - Intelligent text chunking with semantic boundary detection
-        - Comprehensive metadata extraction and enrichment
-        - File validation and security compliance
-        - Memory-efficient processing for large document collections
-    
-    PDF Processing Features:
-        - Multiple backend support (pdfplumber, PyMuPDF, PyPDF2)
-        - Automatic fallback between parsers for optimal results
-        - Table extraction and structured content handling
-        - Layout-aware text extraction for complex documents
-        - Quality validation and content verification
-    
-    Chunking Strategy:
-        - Configurable chunk sizes optimized for RAG systems
-        - Intelligent overlap to preserve context across boundaries
-        - Semantic-aware splitting to maintain document coherence
-        - Metadata propagation across all generated chunks
-        - Quality metrics for chunk assessment
-    
-    Security and Validation:
-        - File size limits to prevent resource exhaustion
-        - File type validation for security compliance
-        - Path traversal protection and input sanitization
-        - Content validation and quality assessment
-        - Error handling with detailed diagnostics
+    Handles PDF, TXT, and MD files with intelligent chunking and metadata enrichment.
+    Supports multiple PDF backends (pdfplumber, PyMuPDF, PyPDF2) with fallbacks.
     
     Attributes:
-        chunk_size (int): Maximum characters per document chunk for optimal processing.
-        chunk_overlap (int): Character overlap between chunks to preserve context.
-        max_file_size (int): Maximum file size in bytes for security and performance.
+        chunk_size (int): Maximum characters per chunk.
+        chunk_overlap (int): Character overlap between chunks.
+        max_file_size (int): Maximum file size in bytes.
     
     Example:
         ```python
-        # Initialize with default configuration
         processor = DocumentProcessor()
-        
-        # Process restaurant partnership contract
-        contract_chunks = processor.process_file(
-            file_path="partnership_agreement.pdf",
-            document_metadata={
-                "partner_name": "SushiExpress24-7",
-                "document_type": "contract",
-                "contract_date": "2022-03-10"
-            }
-        )
-        
-        # Process payout report text
-        payout_chunks = processor.process_text(
-            text=financial_report_content,
-            document_metadata={
-                "partner_name": "SushiExpress24-7",
-                "document_type": "payout_report",
-                "report_period": "2024-07-21"
-            }
-        )
-        
-        # Validate processing results
-        for chunk in contract_chunks:
-            print(f"Chunk {chunk['chunk_id']}: {len(chunk['content'])} characters")
+        chunks = processor.process_file("contract.pdf", {"partner": "Restaurant"})
         ```
-    
-    Configuration:
-        The service uses configuration values from settings for:
-        - chunk_size: Optimal chunk size for RAG processing
-        - chunk_overlap: Context preservation between chunks
-        - max_file_size_mb: Security limit for uploaded files
-    
-    Backend Selection:
-        PDF processing backends are selected based on:
-        - Document complexity and layout requirements
-        - Performance considerations for large files
-        - Availability of installed libraries
-        - Quality of extracted content
-    
-    Raises:
-        FileNotFoundError: When specified file paths do not exist.
-        ValueError: When file size exceeds limits or unsupported formats.
-        ProcessingError: When text extraction fails across all backends.
-        SecurityError: When file validation fails security checks.
-    
-    Note:
-        This service requires at least one PDF processing library (pdfplumber,
-        PyMuPDF, or PyPDF2) for PDF document support. Multiple backends provide
-        redundancy and optimization for different document characteristics.
     """
     
     def __init__(self):
@@ -282,107 +113,29 @@ class DocumentProcessor:
         self.max_file_size = settings.max_file_size_mb * 1024 * 1024  # Convert to bytes
     
     def process_file(self, file_path: str, document_metadata: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
-        """Process document files with comprehensive text extraction and intelligent chunking.
-        
-        This method provides end-to-end document processing for various file formats,
-        implementing robust text extraction with multiple backend support, comprehensive
-        validation, and intelligent chunking optimized for RAG system integration.
-        The processing pipeline ensures reliable content extraction even from complex
-        document layouts and formats.
-        
-        Processing Pipeline:
-            1. File existence and accessibility validation
-            2. Security checks including file size and type validation
-            3. Format detection and appropriate backend selection
-            4. Text extraction with quality validation
-            5. Intelligent chunking with semantic preservation
-            6. Metadata enrichment and tracking
-            7. Quality assurance and error handling
-        
-        Security Features:
-            - File size validation to prevent resource exhaustion
-            - File type validation for security compliance
-            - Path traversal protection
-            - Content sanitization and validation
-        
-        Text Extraction:
-            - PDF: Multiple backend support (pdfplumber, PyMuPDF, PyPDF2)
-            - TXT: Direct text file reading with encoding detection
-            - MD: Markdown file processing with structure preservation
-            - Automatic fallback between backends for optimal results
-        
-        Metadata Generation:
-            - File system metadata (path, name, size, type)
-            - Processing metadata (timestamp, character count)
-            - Custom metadata integration
-            - Document fingerprinting for tracking
+        """Process document files with text extraction and chunking.
         
         Args:
-            file_path (str): Absolute or relative path to the document file
-                for processing. Must point to an existing, readable file
-                in a supported format (PDF, TXT, MD).
+            file_path (str): Path to document file (PDF, TXT, MD).
             document_metadata (Optional[Dict[str, Any]]): Additional metadata
-                to associate with the document and all generated chunks.
-                Common fields include partner_name, document_type,
-                contract_date, and business-specific identifiers.
+                for document and chunks.
         
         Returns:
-            List[Dict[str, Any]]: List of document chunks with comprehensive
-                metadata. Each chunk contains:
-                - content: Extracted text content for the chunk
-                - chunk_id: Unique identifier for the chunk
-                - chunk_index: Sequential position in the document
-                - file_path, file_name, file_size, file_type: File metadata
-                - processed_at: Processing timestamp
-                - total_characters: Character count for the chunk
-                - Additional custom metadata from document_metadata parameter
+            List[Dict[str, Any]]: Document chunks with metadata including
+                content, chunk_id, file info, and processing timestamp.
         
         Raises:
-            FileNotFoundError: When the specified file path does not exist
-                or is not accessible for reading.
-            ValueError: When file size exceeds configured limits, file format
-                is unsupported, or no extractable text content is found.
-            ProcessingError: When text extraction fails across all available
-                backends or processing encounters irrecoverable errors.
-            SecurityError: When file validation fails security checks or
-                file access is restricted.
+            FileNotFoundError: File path does not exist.
+            ValueError: File size exceeds limits or unsupported format.
+            ProcessingError: Text extraction fails across all backends.
         
         Example:
             ```python
-            # Process restaurant partnership contract
-            contract_chunks = processor.process_file(
-                file_path="/uploads/sushi_express_contract.pdf",
-                document_metadata={
-                    "partner_name": "SushiExpress24-7",
-                    "document_type": "contract",
-                    "platform": "SkipTheDishes",
-                    "contract_date": "2022-03-10",
-                    "business_category": "restaurant"
-                }
+            chunks = processor.process_file(
+                "contract.pdf", 
+                {"partner_name": "Restaurant", "type": "contract"}
             )
-            
-            # Validate processing results
-            print(f"Generated {len(contract_chunks)} chunks")
-            for chunk in contract_chunks[:3]:  # Show first 3 chunks
-                print(f"Chunk {chunk['chunk_index']}: {len(chunk['content'])} chars")
             ```
-        
-        Performance Considerations:
-            - Large files are processed in memory-efficient manner
-            - Multiple PDF backends provide optimization options
-            - Chunking strategy balances context preservation with processing efficiency
-            - Metadata processing is optimized for minimal overhead
-        
-        Quality Assurance:
-            - Text extraction quality validation
-            - Content completeness verification
-            - Chunk coherence assessment
-            - Error recovery and reporting
-        
-        Note:
-            The method automatically selects the most appropriate text extraction
-            backend based on file format and document characteristics. For PDF
-            files, it attempts multiple backends to ensure optimal text quality.
         """
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"File not found: {file_path}")

--- a/src/services/embedding_service.py
+++ b/src/services/embedding_service.py
@@ -1,75 +1,20 @@
-"""Advanced OpenAI embedding service for semantic document processing and vector operations.
+"""OpenAI embedding service for document vectorization and semantic search.
 
-This module provides a comprehensive embedding service built on OpenAI's state-of-the-art
-text-embedding-ada-002 model, specifically optimized for financial document analysis
-and restaurant partnership contract processing. It handles large-scale document
-vectorization with intelligent batching, rate limiting, and error handling.
+Provides text embedding generation using OpenAI's Ada-002 model with batch processing,
+rate limiting, and similarity calculations for financial document analysis.
 
-The service transforms textual content into high-dimensional vector representations
-that enable semantic search, document similarity analysis, and context-aware retrieval
-for the RAG (Retrieval-Augmented Generation) pipeline. It supports both single
-document and batch processing modes with production-grade reliability.
-
-Key Capabilities:
-    - High-quality text embedding generation using OpenAI's Ada-002 model
-    - Intelligent batch processing with configurable size and rate limiting
-    - Automatic text truncation with word boundary preservation
-    - Cosine similarity calculations for semantic comparison
-    - Robust error handling and connection validation
-    - Memory-efficient processing for large document collections
-
-Technical Specifications:
-    - Model: text-embedding-ada-002 (1536 dimensions)
-    - Token Limit: 8,191 tokens per input
-    - Batch Size: Configurable (default 100 documents)
-    - Rate Limiting: Automatic delays between API calls
-    - Similarity Metric: Cosine similarity for vector comparison
-
-Integration Points:
-    - Document processing pipeline for chunk vectorization
-    - OpenSearch indexing for semantic document storage
-    - RAG service for context retrieval and similarity matching
-    - Financial analysis workflows for document comparison
+Key Features:
+    - Text-to-vector embedding generation
+    - Batch processing with rate limiting
+    - Cosine similarity calculations
+    - Document chunk enhancement
 
 Example:
     ```python
-    # Initialize embedding service
-    embedding_service = EmbeddingService()
-    
-    # Generate single embedding
-    embedding = embedding_service.generate_embedding("Contract terms and conditions")
-    
-    # Process document chunks in batch
-    chunks_with_embeddings = embedding_service.add_embeddings_to_chunks(document_chunks)
-    
-    # Calculate semantic similarity
-    similarity = embedding_service.calculate_similarity(embedding1, embedding2)
+    service = EmbeddingService()
+    embedding = service.generate_embedding("Contract terms")
+    similarity = service.calculate_similarity(emb1, emb2)
     ```
-
-Performance Considerations:
-    - Batch processing reduces API overhead and improves throughput
-    - Rate limiting prevents API quota exhaustion
-    - Text truncation ensures compatibility with model limits
-    - Connection testing validates service availability before processing
-
-Error Handling:
-    - Graceful degradation for failed embedding generation
-    - Comprehensive logging for debugging and monitoring
-    - Validation of input parameters and API responses
-    - Recovery mechanisms for batch processing failures
-
-Dependencies:
-    - openai: Official OpenAI Python SDK for API access
-    - asyncio: Asynchronous processing capabilities
-    - logging: Comprehensive operation monitoring
-
-Note:
-    This service requires a valid OpenAI API key with sufficient quota for
-    embedding generation. Ensure proper configuration before use in production
-    environments.
-
-Version:
-    2.0.0 - Enhanced with batch processing and production optimizations
 """
 import logging
 from typing import List, Dict, Any, Optional
@@ -84,142 +29,32 @@ logger = logging.getLogger(__name__)
 
 
 class EmbeddingService:
-    """Production-grade embedding service for semantic document processing and analysis.
+    """OpenAI embedding service for document vectorization and semantic analysis.
     
-    This service provides enterprise-level text embedding capabilities using OpenAI's
-    advanced Ada-002 model, specifically optimized for financial document analysis
-    and restaurant partnership contract processing. It implements intelligent batching,
-    rate limiting, and comprehensive error handling for large-scale document processing.
+    Generates text embeddings using Ada-002 model with batch processing, rate limiting,
+    and similarity calculations for financial document analysis.
     
-    The service transforms textual content into high-dimensional semantic vectors that
-    enable sophisticated document retrieval, similarity analysis, and context-aware
-    search capabilities. It serves as the foundation for the RAG pipeline's semantic
-    understanding and document matching algorithms.
-    
-    Key Features:
-        - OpenAI Ada-002 model integration for superior embedding quality
-        - Intelligent batch processing with configurable size limits
-        - Automatic rate limiting to prevent API quota exhaustion
-        - Smart text truncation with word boundary preservation
-        - Comprehensive error handling and recovery mechanisms
-        - Connection validation and health monitoring
-        - Cosine similarity calculations for semantic comparison
-    
-    Processing Capabilities:
-        - Single document embedding generation
-        - Batch processing for large document collections
-        - Automatic chunk enhancement with embedding metadata
-        - Memory-efficient processing for production workloads
-        - Configurable processing parameters for optimization
-    
-    Technical Configuration:
-        - Model: text-embedding-ada-002 (1536-dimensional vectors)
-        - Token Limit: 8,191 tokens per input (auto-truncation)
-        - Default Batch Size: 100 documents per API call
-        - Rate Limit Delay: 1.0 seconds between batches
-        - Similarity Metric: Cosine similarity for vector comparison
+    Features:
+        - Single and batch embedding generation
+        - Automatic text truncation and rate limiting
+        - Cosine similarity calculations
+        - Document chunk enhancement
     
     Attributes:
-        client (OpenAI): Configured OpenAI API client for embedding requests.
-        model (str): OpenAI embedding model identifier (ada-002).
-        max_tokens (int): Maximum token limit for input text processing.
-        batch_size (int): Number of documents processed per API batch.
-        rate_limit_delay (float): Delay in seconds between API calls.
-    
-    Example:
-        ```python
-        # Initialize service with automatic configuration
-        embedding_service = EmbeddingService()
-        
-        # Generate embedding for single text
-        embedding = embedding_service.generate_embedding(
-            "Commission rate: 15% of gross order value"
-        )
-        
-        # Process document chunks with embeddings
-        enhanced_chunks = embedding_service.add_embeddings_to_chunks([
-            {"content": "Contract terms...", "chunk_id": "1"},
-            {"content": "Payout details...", "chunk_id": "2"}
-        ])
-        
-        # Calculate semantic similarity
-        similarity_score = embedding_service.calculate_similarity(
-            embedding1, embedding2
-        )
-        ```
-    
-    Integration:
-        This service integrates with:
-        - Document processing pipeline for chunk vectorization
-        - OpenSearch service for semantic document storage
-        - RAG service for context retrieval and similarity matching
-        - Financial analysis workflows for document comparison
-    
-    Raises:
-        ValueError: When OpenAI API key is not configured or invalid input provided.
-        ConnectionError: When OpenAI API is unavailable or rate limited.
-        RuntimeError: When embedding generation fails due to service issues.
-    
-    Note:
-        Requires a valid OpenAI API key with sufficient quota for embedding
-        generation. The service automatically handles rate limiting and error
-        recovery to ensure reliable operation in production environments.
+        client: OpenAI API client
+        model: Ada-002 embedding model
+        max_tokens: Token limit (8,191)
+        batch_size: Documents per batch (100)
+        rate_limit_delay: Delay between batches (1.0s)
     """
     
     def __init__(self):
-        """Initialize the embedding service with OpenAI integration and production configurations.
+        """Initialize embedding service with OpenAI client and configuration.
         
-        Sets up the complete embedding service infrastructure including OpenAI client
-        initialization, model configuration, and production-optimized parameters for
-        reliable large-scale document processing. The initialization includes
-        comprehensive validation and configuration setup.
-        
-        Configuration Setup:
-            - OpenAI API client with authenticated access
-            - Ada-002 model selection for optimal embedding quality
-            - Token limits and batch size optimization
-            - Rate limiting parameters for API compliance
-            - Error handling and logging infrastructure
-        
-        Production Parameters:
-            - Model: text-embedding-ada-002 for superior semantic understanding
-            - Token Limit: 8,191 tokens (maximum for Ada-002 model)
-            - Batch Size: 100 documents per API call for efficiency
-            - Rate Limit: 1.0 second delay between batches
-            - Auto-truncation: Smart text truncation with word boundaries
-        
-        Security Validation:
-            - OpenAI API key presence verification
-            - Environment variable configuration check
-            - Service connectivity validation preparation
+        Sets up Ada-002 model, batch processing, and rate limiting parameters.
         
         Raises:
-            ValueError: When OpenAI API key is not configured in environment
-                variables or settings. Includes detailed error message for
-                troubleshooting.
-            ImportError: When OpenAI SDK is not properly installed or
-                incompatible version is detected.
-            ConnectionError: When initial OpenAI service connection
-                validation fails during client setup.
-        
-        Environment Requirements:
-            - OPENAI_API_KEY: Valid OpenAI API key with embedding permissions
-            - Network connectivity to OpenAI API endpoints
-            - Sufficient API quota for planned embedding operations
-        
-        Example:
-            ```python
-            # Automatic initialization with environment configuration
-            embedding_service = EmbeddingService()
-            
-            # Service is ready for embedding generation
-            embedding = embedding_service.generate_embedding("Sample text")
-            ```
-        
-        Note:
-            This initialization method assumes that the OpenAI API key is
-            properly configured in the environment. The service will validate
-            connectivity and permissions during the first embedding operation.
+            ValueError: When OpenAI API key is not configured.
         """
         if not settings.openai_api_key:
             raise ValueError("OpenAI API key is required. Please set OPENAI_API_KEY in your environment.")
@@ -231,81 +66,20 @@ class EmbeddingService:
         self.rate_limit_delay = 1.0  # Delay between API calls to avoid rate limits
     
     def generate_embedding(self, text: str) -> List[float]:
-        """Generate high-quality semantic embedding vector for individual text input.
+        """Generate semantic embedding vector for text using Ada-002 model.
         
-        This method transforms textual content into a high-dimensional vector
-        representation using OpenAI's advanced Ada-002 embedding model. The
-        resulting embeddings capture semantic meaning and enable sophisticated
-        similarity comparisons and document retrieval operations.
-        
-        Processing Pipeline:
-            1. Input validation and empty text checking
-            2. Intelligent text truncation with word boundary preservation
-            3. OpenAI API embedding generation with error handling
-            4. Vector validation and dimension verification
-            5. Comprehensive logging for monitoring and debugging
-        
-        Text Processing:
-            - Automatic truncation for texts exceeding token limits
-            - Word boundary preservation to maintain semantic integrity
-            - Empty text validation to prevent API errors
-            - Character encoding compatibility checks
-        
-        Quality Assurance:
-            - Embedding dimension validation (1536 for Ada-002)
-            - Vector completeness verification
-            - Error handling with descriptive messages
-            - Performance logging for optimization
+        Transforms text into 1536-dimensional vector with automatic truncation
+        and validation.
         
         Args:
-            text (str): Input text content for embedding generation.
-                Can be contract clauses, payout descriptions, or any
-                textual content requiring semantic analysis. Must be
-                non-empty and contain meaningful content.
+            text: Input text content for embedding generation.
         
         Returns:
-            List[float]: High-dimensional embedding vector (1536 dimensions)
-                representing the semantic meaning of the input text.
-                Values are normalized floats suitable for cosine
-                similarity calculations and vector storage.
+            1536-dimensional embedding vector as list of floats.
         
         Raises:
-            ValueError: When input text is empty, None, or contains only
-                whitespace. Also raised when embedding generation fails
-                due to content or API issues.
-            ConnectionError: When OpenAI API is unavailable, rate limited,
-                or returns service errors.
-            TokenLimitError: When text cannot be processed due to extreme
-                length or formatting issues.
-        
-        Example:
-            ```python
-            # Generate embedding for contract clause
-            clause_embedding = embedding_service.generate_embedding(
-                "Commission rate shall be 15% of gross order value excluding taxes"
-            )
-            
-            # Generate embedding for payout description
-            payout_embedding = embedding_service.generate_embedding(
-                "Weekly payout: $2,925.00 after service fees and penalties"
-            )
-            
-            # Calculate semantic similarity
-            similarity = embedding_service.calculate_similarity(
-                clause_embedding, payout_embedding
-            )
-            ```
-        
-        Performance:
-            - Single API call for individual text processing
-            - Automatic caching considerations for repeated content
-            - Optimized for real-time embedding generation
-            - Memory efficient for production workloads
-        
-        Note:
-            For batch processing of multiple texts, use generate_embeddings_batch()
-            method which provides superior performance and rate limit handling
-            for large document collections.
+            ValueError: When text is empty or embedding generation fails.
+            ConnectionError: When OpenAI API is unavailable.
         """
         if not text.strip():
             raise ValueError("Text cannot be empty")

--- a/src/services/langchain_document_service.py
+++ b/src/services/langchain_document_service.py
@@ -1,89 +1,19 @@
-"""Advanced LangChain-integrated document processing service for enterprise RAG applications.
+"""LangChain-integrated document processing for RAG applications.
 
-This module provides a sophisticated document processing pipeline that leverages
-LangChain's advanced text splitting and document handling capabilities, specifically
-optimized for financial contract analysis and restaurant partnership document
-processing. It serves as the bridge between raw document content and the RAG
-system's semantic understanding capabilities.
+Provides document processing using LangChain's RecursiveCharacterTextSplitter,
+optimized for financial contracts and restaurant partnership documents.
 
-The service implements LangChain's RecursiveCharacterTextSplitter with custom
-configurations tailored for legal and financial documents, ensuring optimal
-chunk boundaries that preserve semantic coherence while maintaining compatibility
-with embedding models and vector storage systems.
-
-Key Capabilities:
-    - LangChain Document object creation for RAG pipeline integration
-    - Intelligent text splitting with recursive character-based strategies
-    - Semantic boundary preservation for contract and financial documents
-    - Comprehensive metadata management and propagation
-    - Multi-format document support with unified output format
-    - Production-grade error handling and quality validation
-
-LangChain Integration:
-    - RecursiveCharacterTextSplitter for optimal chunk creation
-    - Document schema compatibility for seamless RAG operations
-    - Metadata standardization for consistent document handling
-    - Vector store preparation with proper document formatting
-
-Text Splitting Strategy:
-    - Hierarchical separators for logical document structure preservation
-    - Configurable chunk sizes optimized for embedding generation
-    - Intelligent overlap to maintain context across boundaries
-    - Paragraph and sentence boundary awareness
-    - Character-level fallback for edge cases
-
-Document Processing Pipeline:
-    1. File validation and format detection
-    2. Text extraction using optimized backends
-    3. LangChain-based intelligent text splitting
-    4. Document object creation with metadata enrichment
-    5. Quality validation and coherence checking
-    6. RAG-ready output formatting
+Key Features:
+    - LangChain Document object creation for RAG integration
+    - Semantic boundary preservation with recursive splitting
+    - Multi-format support with unified output format
+    - Comprehensive metadata management
 
 Example:
     ```python
-    # Initialize LangChain document processor
     processor = LangChainDocumentProcessor()
-    
-    # Process contract for RAG pipeline
-    documents = processor.process_file_for_rag(
-        file_path="partnership_agreement.pdf",
-        document_metadata={
-            "partner_name": "SushiExpress24-7",
-            "document_type": "contract",
-            "business_category": "restaurant"
-        }
-    )
-    
-    # Documents are ready for vector store indexing
-    for doc in documents:
-        print(f"Chunk {doc.metadata['chunk_index']}: {len(doc.page_content)} chars")
+    documents = processor.process_file("contract.pdf", {"partner": "Restaurant"})
     ```
-
-Integration Benefits:
-    - Seamless compatibility with LangChain RAG components
-    - Optimized chunk sizes for embedding model performance
-    - Consistent metadata structure across the pipeline
-    - Enhanced semantic coherence in document splitting
-
-Technical Features:
-    - RecursiveCharacterTextSplitter with custom separator hierarchy
-    - Document metadata standardization and enrichment
-    - Multi-backend text extraction with LangChain formatting
-    - Quality assurance and validation throughout the pipeline
-
-Dependencies:
-    - langchain: Advanced text splitting and document handling
-    - document_service: Base text extraction capabilities
-    - logging: Comprehensive operation monitoring
-
-Note:
-    This service is specifically designed to meet LangChain RAG pipeline
-    requirements while maintaining compatibility with the existing document
-    processing infrastructure.
-
-Version:
-    2.0.0 - Enhanced with LangChain integration and optimized text splitting
 """
 import logging
 from typing import List, Dict, Any, Optional

--- a/src/services/rag_service.py
+++ b/src/services/rag_service.py
@@ -1,60 +1,19 @@
-"""Retrieval-Augmented Generation (RAG) service for financial contract analysis.
+"""RAG service for financial contract analysis.
 
-This module provides a comprehensive RAG implementation specifically designed for financial
-analysis of restaurant partnership contracts and payout reports. It combines OpenAI's GPT-4
-language model with OpenSearch vector storage and LangChain orchestration to deliver
-sophisticated contract discrepancy analysis capabilities.
+Provides AI-powered analysis of restaurant partnership contracts and payout reports
+using OpenAI GPT-4, OpenSearch vector storage, and LangChain orchestration.
 
-The service acts as an AI financial analyst that can:
-- Compare legal contracts with financial payout reports
-- Identify discrepancies in commission rates, fees, and payment terms
-- Generate detailed financial analysis reports with executive summaries
-- Process complex multi-document queries with contextual understanding
-- Provide both simple informational queries and complex analytical insights
-
-Key Components:
-    - FinancialAnalystRAGChain: Main RAG orchestration class
-    - LangChain integration for document processing and retrieval
-    - OpenAI GPT-4 for advanced reasoning and analysis
-    - OpenSearch vector storage for semantic document retrieval
-    - Specialized prompts for financial domain expertise
-
-The service supports multiple analysis modes:
-    - Expert financial analysis with detailed calculations
-    - Executive summary generation for high-level insights
-    - Simple database queries for informational requests
-    - Legacy compatibility for existing integrations
+Key Features:
+    - Contract-to-payout discrepancy detection
+    - Commission rate variance analysis  
+    - Multi-document comparative analysis
+    - Executive summary generation
 
 Example:
     ```python
-    rag_service = FinancialAnalystRAGChain()
-    
-    # Load partner documents for analysis
-    docs = rag_service.load_partner_documents("SushiExpress24-7")
-    
-    # Perform financial discrepancy analysis
-    analysis = rag_service.analyze_query(
-        question="Compare commission rates between contract and payout report",
-        query_type="financial_analysis"
-    )
-    
-    # Generate executive summary
-    summary = rag_service.generate_executive_summary(partner_name="SushiExpress24-7")
+    rag = FinancialAnalystRAGChain()
+    analysis = rag.analyze_contract_discrepancies("SushiExpress24-7")
     ```
-
-Dependencies:
-    - langchain: Document processing and RAG orchestration
-    - openai: GPT-4 language model and embeddings
-    - opensearch: Vector storage and semantic search
-    - pydantic: Configuration management and data validation
-
-Note:
-    This service requires proper configuration of OpenAI API keys and OpenSearch
-    connectivity. Ensure that document indexing is completed before running
-    analysis queries.
-
-Version:
-    2.0.0 - Enhanced with multi-document support and advanced financial analysis
 """
 import logging
 from typing import List, Dict, Any, Optional, Tuple
@@ -78,122 +37,34 @@ logger = logging.getLogger(__name__)
 
 
 class FinancialAnalystRAGChain:
-    """Comprehensive RAG chain for financial analysis of restaurant partnership agreements.
+    """RAG chain for financial analysis of restaurant partnership contracts.
     
-    This class implements a sophisticated Retrieval-Augmented Generation system specifically
-    designed for analyzing restaurant partnership contracts and their corresponding payout
-    reports. It acts as an AI financial analyst capable of identifying discrepancies,
-    calculating variances, and generating detailed financial analysis reports.
+    Analyzes restaurant partnership contracts and payout reports to identify
+    discrepancies using GPT-4, OpenSearch, and LangChain.
     
-    The system combines multiple AI technologies:
-    - OpenAI GPT-4 for advanced reasoning and financial analysis
-    - OpenAI Ada-002 embeddings for semantic document retrieval
-    - OpenSearch vector database for scalable document storage
-    - LangChain for orchestrating the RAG pipeline
-    - Custom financial domain prompts for expert-level analysis
-    
-    Key Capabilities:
-        - Multi-document financial discrepancy analysis
+    Key Features:
+        - Contract-to-payout discrepancy analysis
         - Commission rate variance calculations
-        - Fee structure comparisons between contracts and reports
-        - Executive summary generation for stakeholder reporting
-        - Contextual query processing with domain expertise
-        - Support for various restaurant partnership platforms
-    
-    Supported Analysis Types:
-        - Expert financial analysis with detailed calculations
-        - Executive summaries for high-level business insights
-        - Simple database queries for informational requests
-        - Legacy format analysis for backward compatibility
-    
-    Document Processing:
-        - PDF contract parsing and text extraction
-        - Payout report data normalization
-        - Multi-partner document organization
-        - Semantic chunking for optimal retrieval
-    
-    Attributes:
-        document_processor (LangChainDocumentProcessor): Handles document processing operations.
-        opensearch_service (OpenSearchService): Manages vector storage and retrieval.
-        llm (ChatOpenAI): GPT-4 language model for analysis and reasoning.
-        embeddings (OpenAIEmbeddings): Ada-002 model for document embeddings.
-        expert_analyst_prompt (PromptTemplate): Template for expert financial analysis.
-        detailed_report_prompt (PromptTemplate): Template for comprehensive reports.
-        executive_summary_prompt (PromptTemplate): Template for executive summaries.
-        financial_analyst_prompt (PromptTemplate): Legacy compatibility template.
-        simple_database_prompt (PromptTemplate): Template for simple queries.
-        partner_documents_cache (Dict): In-memory cache for partner document storage.
+        - Executive summary generation
+        - Multi-document analysis
     
     Example:
         ```python
-        # Initialize the RAG chain
-        rag_chain = FinancialAnalystRAGChain()
-        
-        # Load documents for a specific partner
-        docs = rag_chain.load_partner_documents("SushiExpress24-7")
-        
-        # Perform financial analysis
-        analysis_result = rag_chain.analyze_query(
-            question="Identify commission rate discrepancies between contract and payout report",
-            query_type="financial_analysis"
-        )
-        
-        # Generate executive summary
-        summary = rag_chain.generate_executive_summary(
-            partner_name="SushiExpress24-7"
-        )
+        rag = FinancialAnalystRAGChain()
+        analysis = rag.analyze_contract_discrepancies("SushiExpress24-7")
+        summary = rag.generate_executive_summary("session_id", "file.pdf")
         ```
-    
-    Note:
-        This class requires proper initialization of OpenAI API credentials and
-        OpenSearch connectivity. Ensure that document indexing is completed
-        before attempting analysis operations.
-    
-    Raises:
-        ConnectionError: When OpenSearch or OpenAI services are unavailable.
-        ValueError: When required configuration parameters are missing.
-        DocumentNotFoundError: When requested partner documents are not indexed.
     """
     
     def __init__(self):
-        """Initialize the Financial Analyst RAG chain with all required components.
+        """Initialize the RAG chain with OpenAI and OpenSearch components.
         
-        Sets up the complete RAG pipeline including document processing, vector storage,
-        language models, embeddings, and specialized financial analysis prompts. The
-        initialization creates a production-ready system optimized for financial
-        contract analysis with low-temperature settings for consistent results.
-        
-        Components Initialized:
-            - LangChain document processor for PDF and text handling
-            - OpenSearch service for vector storage and semantic retrieval
-            - GPT-4 language model with financial analysis optimization
-            - Ada-002 embeddings for high-quality document representations
-            - Specialized prompt templates for different analysis types
-            - Partner document caching system for performance optimization
-        
-        Configuration Settings:
-            - GPT-4 model for advanced reasoning capabilities
-            - Temperature 0.1 for consistent analytical outputs
-            - Streaming disabled to prevent text fragmentation
-            - Ada-002 embeddings for optimal semantic understanding
-        
-        Prompt Templates:
-            - Expert analyst: Comprehensive financial analysis with calculations
-            - Detailed report: Full analysis with structured reporting format
-            - Executive summary: High-level insights for stakeholders
-            - Legacy format: Backward compatibility with existing systems
-            - Simple database: Basic informational query responses
+        Sets up GPT-4 for analysis, Ada-002 for embeddings, document processor,
+        and specialized financial analysis prompts.
         
         Raises:
-            ValueError: When OpenAI API key is not configured in settings.
+            ValueError: When OpenAI API key is not configured.
             ConnectionError: When OpenSearch service is not accessible.
-            ImportError: When required dependencies are not installed.
-        
-        Note:
-            This method assumes that all required environment variables and
-            configuration settings are properly set before instantiation.
-            The partner document cache is initialized empty and will be
-            populated during document loading operations.
         """
         self.document_processor = LangChainDocumentProcessor()
         self.opensearch_service = OpenSearchService()
@@ -242,41 +113,16 @@ class FinancialAnalystRAGChain:
         self.partner_documents_cache = {}  # Cache for partner documents
         
     def _clean_response_text(self, text: str) -> str:
-        """Clean up potential streaming artifacts and formatting issues in AI responses.
+        """Clean up streaming artifacts and formatting issues in AI responses.
         
-        This method addresses common issues that can occur in AI-generated text,
-        particularly when streaming is involved or when text formatting is disrupted.
-        It intelligently reconstructs fragmented text while preserving legitimate
-        line breaks and formatting.
-        
-        Cleaning Operations:
-            - Removes single-character lines that are streaming artifacts
-            - Reconstructs fragmented numbers and currency values
-            - Fixes separated decimal points and commas
-            - Repairs common word fragmentations
-            - Preserves intentional formatting and line breaks
-            - Removes excessive whitespace while maintaining readability
-        
-        Text Reconstruction:
-            - Currency: "2\\n,\\n925.00" → "2,925.00"
-            - Decimals: "925\\n.\\n00" → "925.00"
-            - Common words: "w\\ni\\nt\\nh" → "with"
-            - Conservative approach to avoid joining legitimate word boundaries
+        Fixes fragmented numbers, currency values, and common word separations
+        caused by streaming or text processing issues.
         
         Args:
-            text (str): Raw AI response text that may contain streaming artifacts
-                or formatting issues requiring cleanup.
+            text: Raw AI response text with potential artifacts.
         
         Returns:
-            str: Cleaned and properly formatted text with artifacts removed
-                and fragmented content reconstructed while preserving
-                intentional formatting.
-        
-        Note:
-            This method uses conservative patterns to avoid incorrectly joining
-            text that should remain separated. It focuses on obvious streaming
-            artifacts and common formatting issues rather than aggressive
-            text reconstruction.
+            Cleaned text with artifacts removed and proper formatting.
         """
         import re
         
@@ -339,56 +185,16 @@ class FinancialAnalystRAGChain:
         return cleaned_text.strip()
         
     def _is_simple_database_query(self, question: str) -> bool:
-        """Classify user questions to determine appropriate analysis approach.
+        """Classify user questions as simple database queries or complex analysis.
         
-        This method analyzes user questions to determine whether they require
-        simple informational responses or complex financial analysis. This
-        classification enables the system to use the most appropriate prompt
-        template and response format for optimal user experience.
-        
-        Classification Logic:
-            - Simple queries: Basic information requests about available data
-            - Complex queries: Financial analysis requiring calculation and reasoning
-            - Hybrid detection: Balances simple patterns with analytical indicators
-            - Length heuristics: Very short questions typically seek simple information
-        
-        Simple Query Indicators:
-            - "list", "names", "show me", "what are", "which", "how many"
-            - "all restaurants", "all partners", "all documents"
-            - "from db", "in database", "available", "stored"
-            - Questions under 5 words without analytical keywords
-        
-        Complex Query Indicators:
-            - "analyze", "discrepancy", "compare", "calculate", "reconcile"
-            - "payout", "commission", "fee", "penalty", "financial", "money"
-            - "difference", "variance", "explanation", "why", "how much"
-            - Financial terms requiring analytical reasoning
+        Determines whether to use simple informational response or detailed
+        financial analysis based on question keywords and patterns.
         
         Args:
-            question (str): The user's question to be classified for
-                appropriate processing approach.
+            question: User's question to classify.
         
         Returns:
-            bool: True if the question is a simple database query requiring
-                basic informational response, False if it requires complex
-                financial analysis with calculations and reasoning.
-        
-        Examples:
-            Simple queries:
-                - "List all restaurant names"
-                - "Show me available documents"
-                - "What partners are in the database?"
-            
-            Complex queries:
-                - "Analyze commission rate discrepancies"
-                - "Compare payout amounts with contract terms"
-                - "Calculate variance in delivery fees"
-        
-        Note:
-            This classification directly impacts the prompt template selection
-            and response format. Misclassification can lead to overly complex
-            responses for simple queries or insufficient detail for analytical
-            requests.
+            True for simple queries (lists, names, counts), False for analysis.
         """
         question_lower = question.lower().strip()
         
@@ -423,73 +229,20 @@ class FinancialAnalystRAGChain:
         return False
         
     def load_partner_documents(self, partner_name: str) -> Dict[str, List[Document]]:
-        """Load and organize all documents for a specific restaurant partner from OpenSearch.
+        """Load and organize all documents for a restaurant partner from OpenSearch.
         
-        This method retrieves all indexed documents associated with a restaurant partner,
-        organizing them by document type for efficient analysis. It implements intelligent
-        caching to improve performance and supports comprehensive document discovery
-        across different partnership platforms.
-        
-        Document Retrieval Process:
-            1. Check partner document cache for existing data
-            2. Query OpenSearch index using partner name matching
-            3. Retrieve document chunks with metadata preservation
-            4. Organize documents by type (contracts, reports, addendums)
-            5. Cache results for subsequent queries
-            6. Log retrieval statistics for monitoring
-        
-        Supported Document Types:
-            - Contracts: Partnership agreements and terms
-            - Payout Reports: Financial transaction records
-            - Addendums: Contract modifications and supplements
-            - Amendments: Legal changes to existing agreements
-        
-        Document Organization:
-            - Groups chunks by document type for targeted analysis
-            - Preserves metadata including partner name and chunk IDs
-            - Maintains content integrity across document fragments
-            - Enables efficient retrieval for specific analysis types
+        Retrieves and caches documents by type (contracts, payout reports) for
+        efficient analysis. Organizes chunks by document type.
         
         Args:
-            partner_name (str): Name of the restaurant partner for which to load
-                documents. Must match the indexed partner_name field in OpenSearch.
-                Case-sensitive matching is used for precise retrieval.
+            partner_name: Restaurant partner name matching indexed documents.
         
         Returns:
-            Dict[str, List[Document]]: Dictionary mapping document types to lists
-                of LangChain Document objects. Each document contains:
-                - page_content: The actual document text content
-                - metadata: Document type, partner name, chunk ID, and other attributes
+            Dictionary mapping document types to lists of LangChain Documents.
         
         Raises:
-            ConnectionError: When OpenSearch service is not accessible or returns errors.
-            ValueError: When partner_name is empty or None.
-            DocumentNotFoundError: When no documents are found for the specified partner.
-        
-        Example:
-            ```python
-            # Load documents for SushiExpress24-7
-            docs = rag_chain.load_partner_documents("SushiExpress24-7")
-            
-            # Access different document types
-            contracts = docs.get("contract", [])
-            reports = docs.get("payout_report", [])
-            
-            # Check document availability
-            if "contract" in docs and "payout_report" in docs:
-                # Perform comparative analysis
-                analysis = rag_chain.compare_documents(contracts, reports)
-            ```
-        
-        Note:
-            This method implements caching to improve performance for repeated
-            queries on the same partner. Cache invalidation is handled automatically
-            when new documents are indexed for the partner.
-        
-        Performance:
-            - First call: Queries OpenSearch and caches results
-            - Subsequent calls: Returns cached data for improved speed
-            - Cache memory usage scales with number of unique partners
+            ConnectionError: When OpenSearch is not accessible.
+            ValueError: When partner_name is empty or no documents found.
         """
         if partner_name in self.partner_documents_cache:
             logger.info(f"Using cached documents for partner: {partner_name}")


### PR DESCRIPTION
- Convert verbose docstrings to concise Google Style format
- Reduce module documentation from 50+ lines to 10-15 lines
- Streamline class and method docstrings while preserving essential info
- Maintain Args/Returns/Raises structure for all public methods
- Update API router documentation for financial analysis endpoints
- Ensure documentation is proportional to code length

Affected files:
- src/services/rag_service.py: RAG pipeline and financial analysis
- src/services/embedding_service.py: OpenAI embedding integration
- src/services/document_service.py: Multi-format document processing
- src/services/langchain_document_service.py: LangChain integration
- src/api/routers/financial_analysis.py: FastAPI financial endpoints