### PR TITLE
refactor: further improve langchain_document_service.py documentation…

### DIFF
--- a/src/services/langchain_document_service.py
+++ b/src/services/langchain_document_service.py
@@ -30,156 +30,27 @@ logger = logging.getLogger(__name__)
 
 
 class LangChainDocumentProcessor:
-    """Enterprise-grade LangChain document processor for advanced RAG pipeline integration.
+    """LangChain document processor for RAG pipeline integration.
     
-    This processor provides sophisticated document handling capabilities that bridge
-    the gap between raw document content and LangChain's RAG ecosystem. It implements
-    intelligent text splitting strategies specifically optimized for financial
-    contracts and restaurant partnership documents, ensuring optimal semantic
-    coherence and RAG system performance.
-    
-    The service leverages LangChain's RecursiveCharacterTextSplitter with custom
-    configurations tailored for legal and financial document structures, providing
-    superior chunk quality compared to basic text splitting approaches. It maintains
-    document context integrity while ensuring compatibility with embedding models
-    and vector storage systems.
-    
-    LangChain Integration Features:
-        - RecursiveCharacterTextSplitter with hierarchical separator strategies
-        - Native Document object creation for seamless RAG compatibility
-        - Metadata standardization following LangChain conventions
-        - Optimized chunk boundaries for embedding model performance
-        - Vector store preparation with consistent formatting
-    
-    Text Splitting Intelligence:
-        - Hierarchical separator strategy preserving document structure
-        - Paragraph boundary awareness for semantic coherence
-        - Sentence-level splitting for natural language preservation
-        - Character-level fallback for edge cases and special content
-        - Configurable overlap to maintain context across chunks
-    
-    Document Processing Capabilities:
-        - Multi-format support (PDF, TXT, MD) with unified output
-        - Comprehensive metadata enrichment and propagation
-        - Quality validation and coherence assessment
-        - Error handling with detailed diagnostic information
-        - Performance optimization for large document collections
-    
-    Metadata Management:
-        - File system metadata (path, name, size, type)
-        - Processing metadata (timestamps, chunk counts)
-        - Business metadata (partner names, document types)
-        - Chunk-specific metadata (indices, sizes, IDs)
-        - Custom metadata integration and propagation
+    Processes documents using RecursiveCharacterTextSplitter optimized for 
+    financial contracts and restaurant partnership documents.
     
     Attributes:
-        base_processor (DocumentProcessor): Core document processing service
-            for text extraction and validation operations.
-        text_splitter (RecursiveCharacterTextSplitter): LangChain text splitter
-            configured with optimal parameters for financial document processing.
+        base_processor (DocumentProcessor): Core text extraction service.
+        text_splitter (RecursiveCharacterTextSplitter): LangChain text splitter.
     
     Example:
         ```python
-        # Initialize processor with default configuration
         processor = LangChainDocumentProcessor()
-        
-        # Process restaurant partnership contract
-        contract_docs = processor.process_file_for_rag(
-            file_path="sushi_express_partnership.pdf",
-            document_metadata={
-                "partner_name": "SushiExpress24-7",
-                "document_type": "contract",
-                "platform": "SkipTheDishes",
-                "effective_date": "2022-03-10"
-            }
-        )
-        
-        # Process payout report
-        payout_docs = processor.process_text_for_rag(
-            text=payout_report_content,
-            base_metadata={
-                "partner_name": "SushiExpress24-7",
-                "document_type": "payout_report",
-                "report_date": "2024-07-21"
-            }
-        )
-        
-        # Combine for comprehensive analysis
-        all_docs = contract_docs + payout_docs
+        docs = processor.process_file_for_rag("contract.pdf", {"partner": "Restaurant"})
         ```
-    
-    Splitting Configuration:
-        The RecursiveCharacterTextSplitter uses hierarchical separators:
-        1. Double newlines (\\n\\n) - Paragraph boundaries
-        2. Single newlines (\\n) - Line boundaries
-        3. Spaces ( ) - Word boundaries
-        4. Characters - Final fallback
-    
-    Quality Assurance:
-        - Chunk size validation for embedding compatibility
-        - Content coherence assessment
-        - Metadata completeness verification
-        - Document structure preservation validation
-    
-    Performance:
-        - Optimized for large document collections
-        - Memory-efficient processing strategies
-        - Configurable parameters for performance tuning
-        - Batch processing capabilities for enterprise workloads
-    
-    Note:
-        This processor is specifically designed to meet LangChain RAG
-        requirements while maintaining high document processing quality
-        and semantic coherence for financial analysis applications.
     """
     
     def __init__(self):
-        """Initialize LangChain document processor with optimized configuration for RAG systems.
+        """Initialize document processor with LangChain text splitter.
         
-        Sets up the complete document processing pipeline with LangChain integration,
-        configuring the RecursiveCharacterTextSplitter with parameters specifically
-        optimized for financial contracts and restaurant partnership documents.
-        The initialization ensures seamless compatibility with RAG pipeline components.
-        
-        Component Initialization:
-            - Base DocumentProcessor for multi-format text extraction
-            - RecursiveCharacterTextSplitter with hierarchical separator strategy
-            - Configuration loading from settings for consistency
-            - Logging infrastructure for operation monitoring
-        
-        Text Splitter Configuration:
-            - Chunk size: Optimized for embedding model performance
-            - Chunk overlap: Configured to preserve context across boundaries
-            - Length function: Character-based for precise control
-            - Hierarchical separators for document structure preservation
-        
-        Separator Hierarchy Strategy:
-            1. Double newlines (\\n\\n): Preserve paragraph boundaries
-            2. Single newlines (\\n): Maintain line structure
-            3. Spaces ( ): Respect word boundaries
-            4. Characters (''): Final fallback for edge cases
-        
-        This hierarchy ensures that text splitting respects natural document
-        structure, maintaining semantic coherence while creating appropriately
-        sized chunks for optimal RAG system performance.
-        
-        Configuration Source:
-            All parameters are loaded from the settings module to ensure
-            consistency across the entire application:
-            - chunk_size: From settings.chunk_size
-            - chunk_overlap: From settings.chunk_overlap
-            - Separator configuration: Optimized for legal/financial documents
-        
-        Integration Benefits:
-            - Seamless compatibility with LangChain RAG components
-            - Consistent chunk formatting across the pipeline
-            - Optimized performance for embedding generation
-            - Enhanced semantic coherence in document splitting
-        
-        Note:
-            The RecursiveCharacterTextSplitter is specifically chosen for its
-            ability to maintain document structure while creating chunks suitable
-            for vector embedding and semantic search operations.
+        Sets up DocumentProcessor and RecursiveCharacterTextSplitter with
+        optimized configuration for financial documents.
         """
         self.base_processor = DocumentProcessor()
         
@@ -197,114 +68,29 @@ class LangChainDocumentProcessor:
         )
         
     def process_file_for_rag(self, file_path: str, document_metadata: Optional[Dict[str, Any]] = None) -> List[Document]:
-        """Process documents into LangChain Document objects optimized for RAG pipeline integration.
-        
-        This method provides comprehensive document processing that transforms raw files
-        into LangChain Document objects with intelligent text splitting and metadata
-        enrichment. It's specifically optimized for restaurant partnership contracts
-        and financial documents, ensuring optimal chunk boundaries and semantic
-        coherence for RAG system performance.
-        
-        Processing Pipeline:
-            1. File validation and accessibility verification
-            2. Format detection and appropriate text extraction
-            3. Quality validation of extracted content
-            4. LangChain RecursiveCharacterTextSplitter application
-            5. Document object creation with metadata enrichment
-            6. Quality assurance and validation
-        
-        LangChain Integration:
-            - Creates native Document objects for seamless RAG compatibility
-            - Applies RecursiveCharacterTextSplitter for optimal chunk boundaries
-            - Standardizes metadata format following LangChain conventions
-            - Ensures consistent formatting for vector store integration
-        
-        Text Splitting Strategy:
-            - Hierarchical separator approach preserving document structure
-            - Paragraph boundary preservation for semantic coherence
-            - Configurable chunk sizes optimized for embedding models
-            - Intelligent overlap to maintain context across boundaries
-        
-        Metadata Enrichment:
-            - File system metadata (path, name, size, type, timestamps)
-            - Processing metadata (chunk indices, counts, IDs)
-            - Business context metadata (partner names, document types)
-            - Custom metadata integration from input parameters
+        """Process files into LangChain Document objects for RAG integration.
         
         Args:
-            file_path (str): Path to the document file for processing.
-                Must point to an existing file in a supported format
-                (PDF, TXT, MD). Path can be absolute or relative.
+            file_path (str): Path to document file (PDF, TXT, MD).
             document_metadata (Optional[Dict[str, Any]]): Additional metadata
-                to associate with all generated Document objects.
-                Common fields include partner_name, document_type,
-                contract_date, and business-specific identifiers.
+                for generated Document objects.
         
         Returns:
-            List[Document]: List of LangChain Document objects ready for
-                RAG pipeline integration. Each Document contains:
-                - page_content: Intelligently chunked text content
-                - metadata: Comprehensive metadata including file info,
-                  chunk details, and custom business context
+            List[Document]: LangChain Document objects with chunked content
+                and comprehensive metadata.
         
         Raises:
-            FileNotFoundError: When the specified file path does not exist
-                or is not accessible for reading.
-            ValueError: When file format is unsupported or no extractable
-                text content is found in the document.
-            ProcessingError: When text extraction or splitting fails
-                due to document issues or system limitations.
-            LangChainError: When Document object creation fails due to
-                formatting or compatibility issues.
+            FileNotFoundError: File path does not exist.
+            ValueError: Unsupported format or no extractable content.
+            ProcessingError: Text extraction or splitting fails.
         
         Example:
             ```python
-            # Process restaurant partnership contract
-            contract_documents = processor.process_file_for_rag(
-                file_path="contracts/sushi_express_partnership.pdf",
-                document_metadata={
-                    "partner_name": "SushiExpress24-7",
-                    "document_type": "contract",
-                    "platform": "SkipTheDishes",
-                    "effective_date": "2022-03-10",
-                    "business_category": "restaurant",
-                    "contract_version": "2.1"
-                }
+            docs = processor.process_file_for_rag(
+                "contract.pdf", 
+                {"partner_name": "Restaurant", "type": "contract"}
             )
-            
-            # Validate processing results
-            print(f"Generated {len(contract_documents)} Document objects")
-            
-            # Examine document structure
-            for i, doc in enumerate(contract_documents[:3]):
-                print(f"Document {i}:")
-                print(f"  Content length: {len(doc.page_content)}")
-                print(f"  Chunk ID: {doc.metadata['chunk_id']}")
-                print(f"  Partner: {doc.metadata['partner_name']}")
             ```
-        
-        Document Object Structure:
-            Each returned Document object contains:
-            - page_content: Chunked text content optimized for embeddings
-            - metadata: Dictionary with comprehensive context information
-              including file metadata, chunk details, and business context
-        
-        Quality Assurance:
-            - Content validation to ensure meaningful text extraction
-            - Chunk size optimization for embedding model compatibility
-            - Metadata completeness verification
-            - Document object format validation for RAG compatibility
-        
-        Performance:
-            - Optimized text splitting for large documents
-            - Memory-efficient processing for enterprise workloads
-            - Configurable parameters for performance tuning
-            - Batch-ready design for large document collections
-        
-        Note:
-            This method is the primary interface for preparing documents
-            for RAG pipeline integration, ensuring optimal compatibility
-            with LangChain components and vector storage systems.
         """
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"File not found: {file_path}")


### PR DESCRIPTION
… conciseness

- Reduce verbose class docstring from 80+ lines to 12 lines
- Shorten __init__ method documentation from 40+ lines to 5 lines
- Streamline process_file_for_rag method docs from 100+ lines to 20 lines
- Maintain Google Style format with essential Args/Returns/Raises
- Preserve key functionality information while removing redundancy
- Keep existing concise documentation for other methods unchanged

Changes:
- Class documentation: Concise LangChain integration overview
- Method documentation: Essential information only
- Remove verbose technical explanations and examples
- Focus on core functionality and parameters